### PR TITLE
Update guarentees `setStatePromise` will resolve

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,42 +1,41 @@
-import { Dispatch, SetStateAction, useCallback, useEffect, useRef, useState } from 'react';
+import { Dispatch, SetStateAction, useCallback, useState } from 'react';
 
 interface UseStatePromiseFn {
-  <T>(initialState: T | (() => T), skipFirst?: boolean): readonly [
-    T,
-    (value: SetStateAction<T>) => Promise<T>,
-    Dispatch<SetStateAction<T>>
-  ];
-  <T = undefined>(skipFirst?: boolean): readonly [
-    T | undefined,
-    (value: SetStateAction<T | undefined>) => Promise<T | undefined>,
-    Dispatch<SetStateAction<T | undefined>>
-  ];
+    <T>(initialState: T | (() => T)): readonly [
+        T,
+        (value: SetStateAction<T>) => Promise<T>,
+        Dispatch<SetStateAction<T>>
+    ];
+    <T = undefined>(): readonly [
+        T | undefined,
+        (value: SetStateAction<T | undefined>) => Promise<T | undefined>,
+        Dispatch<SetStateAction<T | undefined>>
+    ];
 }
 
-export const useStatePromise: UseStatePromiseFn = <T>(initialState?: T, skipFirst = true) => {
-  const [state, setState] = useState(initialState);
-  const first = useRef(skipFirst);
-  const resolver = useRef<((value: T | undefined) => void) | null>(null);
+export const useStatePromise: UseStatePromiseFn = <T>(initialState?: T) => {
+    const [state, setState] = useState(initialState);
 
-  const setStatePromise = useCallback((value: SetStateAction<T>) => {
-    setState(value);
-    return new Promise<T | undefined>((resolve) => {
-      resolver.current = resolve;
-    });
-  }, []);
+    const setStatePromise = useCallback((value: T & ((prevState: T | undefined) => T)) => {
+        if (typeof value === 'function') {
+            return new Promise((resolve) => {
+                setState((prevState: T | undefined) => {
+                    const nextValue = value(prevState);
+                    resolve(nextValue);
+                    return nextValue;
+                });
+            });
+        } else {
+            return new Promise((resolve) => {
+                setState(() => {
+                    resolve(value);
+                    return value;
+                });
+            });
+        }
+    }, []);
 
-  useEffect(() => {
-    if (first.current) {
-      first.current = false;
-      return;
-    }
-    if (resolver.current) {
-      resolver.current(state);
-      resolver.current = null;
-    }
-  }, [state]);
-
-  return [state, setStatePromise, setState] as const;
+    return [state, setStatePromise, setState] as const;
 };
 
 export default useStatePromise;


### PR DESCRIPTION
The current implementation has an unsolved edge where setting state to a value that is presently assigned results in an unresolved promise. This creates multiple issues, and really makes the library unusable. 

The proposed changes solve this issue using core react functionality. Please consider.